### PR TITLE
👷 Fix error when running documentation workflow

### DIFF
--- a/.github/workflows/build-test-documentation.yaml
+++ b/.github/workflows/build-test-documentation.yaml
@@ -7,6 +7,9 @@ on:
 
   workflow_dispatch:
 
+permissions: 
+  contents: write
+
 jobs:
   Build-Test-Documentation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes a recent error when running the build + generate documentation workflow:  `The process '/usr/bin/git' failed with exit code 128`.